### PR TITLE
Fixes #3: Add support for Terraform 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.0.0] - 2019-YY-ZZ
+
+### Changed
+
+- Supported version of Terraform is 0.12. [#3]
+
 ## [0.1.0] - 2019-05-16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SHELL := /usr/bin/env bash
 # Docker build config variables
 CREDENTIALS_PATH 			?= /cft/workdir/credentials.json
 DOCKER_ORG 				:= gcr.io/cloud-foundation-cicd
-DOCKER_TAG_BASE_KITCHEN_TERRAFORM 	?= 1.0.1
+DOCKER_TAG_BASE_KITCHEN_TERRAFORM 	?= 2.0.0
 DOCKER_REPO_BASE_KITCHEN_TERRAFORM 	:= ${DOCKER_ORG}/cft/kitchen-terraform:${DOCKER_TAG_BASE_KITCHEN_TERRAFORM}
 
 # All is the first target in the file so it will get picked up when you just run 'make' on its own

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-google-kms
+# Google KMS Terraform Module
 
 Simple Cloud KMS module that allows managing a keyring, zero or more keys in the keyring, and IAM role bindings on individual keys.
 
@@ -7,6 +7,13 @@ The resources/services/activations/deletions that this module will create/trigge
 - Create a KMS keyring in the provided project
 - Create zero or more keys in the keyring
 - Create IAM role bindings for owners, encrypters, decrypters
+
+## Compatibility
+
+This module is meant for use with Terraform 0.12. If you haven't
+[upgraded][terraform-0.12-upgrade] and need a Terraform 0.11.x-compatible
+version of this module, the last released version intended for Terraform 0.11.x
+is [0.1.0][v0.1.0].
 
 ## Usage
 
@@ -44,7 +51,7 @@ These sections describe requirements for using this module.
 
 The following dependencies must be available:
 
-- [Terraform][terraform] v0.11
+- [Terraform][terraform] v0.12
 - [Terraform Provider for GCP][terraform-provider-gcp] plugin v2.0
 
 ### Service Account

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -21,6 +21,8 @@ provider "google" {
 module "kms" {
   source = "../.."
 
-  project_id  = "${var.project_id}"
-  bucket_name = "${var.bucket_name}"
+  project_id = var.project_id
+  keyring    = var.name
+  location   = "global"
 }
+

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -15,11 +15,12 @@
  */
 
 variable "project_id" {
+  type        = string
   description = "The ID of the project in which to provision resources."
-  type        = "string"
 }
 
-variable "bucket_name" {
-  description = "The name of the bucket to create."
-  type        = "string"
+variable "name" {
+  type        = string
+  description = "The name of the keyring to create."
 }
+

--- a/main.tf
+++ b/main.tf
@@ -14,25 +14,21 @@
  * limitations under the License.
  */
 
-terraform {
-  required_version = "~> 0.11.0"
-}
-
 locals {
-  keys_by_name = "${zipmap(var.keys, google_kms_crypto_key.key.*.self_link)}"
+  keys_by_name = zipmap(var.keys, google_kms_crypto_key.key.*.self_link)
 }
 
 resource "google_kms_key_ring" "key_ring" {
-  name     = "${var.keyring}"
-  project  = "${var.project_id}"
-  location = "${var.location}"
+  name     = var.keyring
+  project  = var.project_id
+  location = var.location
 }
 
 resource "google_kms_crypto_key" "key" {
-  count           = "${length(var.keys)}"
-  name            = "${element(var.keys, count.index)}"
-  key_ring        = "${google_kms_key_ring.key_ring.self_link}"
-  rotation_period = "${var.key_rotation_period}"
+  count           = length(var.keys)
+  name            = var.keys[count.index]
+  key_ring        = google_kms_key_ring.key_ring.self_link
+  rotation_period = var.key_rotation_period
 
   lifecycle {
     prevent_destroy = true
@@ -40,43 +36,29 @@ resource "google_kms_crypto_key" "key" {
 }
 
 resource "google_kms_crypto_key_iam_binding" "owners" {
-  count = "${length(var.set_owners_for)}"
+  count = length(var.set_owners_for)
   role  = "roles/owner"
 
-  crypto_key_id = "${lookup(
-    local.keys_by_name,
-    element(var.set_owners_for, count.index)
-  )}"
+  crypto_key_id = local.keys_by_name[var.set_owners_for[count.index]]
 
-  members = [
-    "${compact(split(",", element(var.owners, count.index)))}",
-  ]
+  members = compact(split(",", var.owners[count.index]))
 }
 
 resource "google_kms_crypto_key_iam_binding" "decrypters" {
-  count = "${length(var.set_decrypters_for)}"
+  count = length(var.set_decrypters_for)
   role  = "roles/cloudkms.cryptoKeyDecrypter"
 
-  crypto_key_id = "${lookup(
-    local.keys_by_name,
-    element(var.set_decrypters_for, count.index)
-  )}"
+  crypto_key_id = local.keys_by_name[var.set_decrypters_for[count.index]]
 
-  members = [
-    "${compact(split(",", element(var.decrypters, count.index)))}",
-  ]
+  members = compact(split(",", var.decrypters[count.index]))
 }
 
 resource "google_kms_crypto_key_iam_binding" "encrypters" {
-  count = "${length(var.set_encrypters_for)}"
+  count = length(var.set_encrypters_for)
   role  = "roles/cloudkms.cryptoKeyEncrypter"
 
-  crypto_key_id = "${lookup(
-    local.keys_by_name,
-    element(var.set_encrypters_for, count.index)
-  )}"
+  crypto_key_id = local.keys_by_name[var.set_encrypters_for[count.index]]
 
-  members = [
-    "${compact(split(",", element(var.encrypters, count.index)))}",
-  ]
+  members = compact(split(",", var.encrypters[count.index]))
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,15 +16,16 @@
 
 output "keyring" {
   description = "Self link of the keyring."
-  value       = "${google_kms_key_ring.key_ring.self_link}"
+  value       = google_kms_key_ring.key_ring.self_link
 }
 
 output "keys" {
   description = "Map of key name => key self link."
-  value       = "${local.keys_by_name}"
+  value       = local.keys_by_name
 }
 
 output "keyring_name" {
   description = "Name of the keyring."
-  value       = "${google_kms_key_ring.key_ring.name}"
+  value       = google_kms_key_ring.key_ring.name
 }
+

--- a/test/make.sh
+++ b/test/make.sh
@@ -25,7 +25,8 @@ finish() {
 trap finish EXIT
 # Create a temporary file in the auto-cleaned up directory while avoiding
 # overwriting TMPDIR for other processes.
-# shellcheck disable=SC2120 # (Arguments may be passed, e.g. maketemp -d)
+# shellcheck disable=SC2120
+# (Arguments may be passed, e.g. maketemp -d)
 maketemp() {
   TMPDIR="${DELETE_AT_EXIT}" mktemp "$@"
 }
@@ -76,14 +77,8 @@ function check_terraform() {
   set -e
   echo "Running terraform validate"
   find_files . -name "*.tf" -print0 \
-    | compat_xargs -0 -n1 dirname \
-    | sort -u \
-    | compat_xargs -t -n1 terraform validate --check-variables=false
-  echo "Running terraform fmt"
-  find_files . -name "*.tf" -print0 \
-    | compat_xargs -0 -n1 dirname \
-    | sort -u \
-    | compat_xargs -t -n1 terraform fmt -check=true -write=false
+    | xargs dirname | sort | uniq | xargs -L 1 -i{} \
+    bash -c 'terraform init "{}" > /dev/null && terraform validate "{}" && terraform fmt -check=true -write=false "{}"'
 }
 
 # This function runs 'go fmt' and 'go vet' on every file

--- a/variables.tf
+++ b/variables.tf
@@ -15,53 +15,65 @@
  */
 
 variable "project_id" {
+  type        = string
   description = "Project id where the keyring will be created."
 }
 
 # cf https://cloud.google.com/kms/docs/locations
 variable "location" {
+  type        = string
   description = "Location for the keyring."
 }
 
 variable "keyring" {
+  type        = string
   description = "Keyring name."
 }
 
 variable "keys" {
+  type        = list(string)
   description = "Key names."
   default     = []
 }
 
 variable "set_owners_for" {
+  type        = list(string)
   description = "Name of keys for which owners will be set."
   default     = []
 }
 
 variable "owners" {
+  type        = list(string)
   description = "List of comma-separated owners for each key declared in set_owners_for."
   default     = []
 }
 
 variable "set_encrypters_for" {
+  type        = list(string)
   description = "Name of keys for which encrypters will be set."
   default     = []
 }
 
 variable "encrypters" {
+  type        = list(string)
   description = "List of comma-separated owners for each key declared in set_encrypters_for."
   default     = []
 }
 
 variable "set_decrypters_for" {
+  type        = list(string)
   description = "Name of keys for which decrypters will be set."
   default     = []
 }
 
 variable "decrypters" {
+  type        = list(string)
   description = "List of comma-separated owners for each key declared in set_decrypters_for."
   default     = []
 }
 
 variable "key_rotation_period" {
+  type    = string
   default = "100000s"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-output "keyring_name" {
-  description = "The name of the keyring."
-  value       = module.kms.keyring_name
+terraform {
+  required_version = ">= 0.12"
 }
-


### PR DESCRIPTION
https://github.com/terraform-google-modules/terraform-google-kms/issues/3

- Migrated to the new TF 0.12 syntax
- Added types for variables
- Removed instances of unnecessary string interpolation
- Removed unnecessary "element" calls
- Run tests locally
- Switched to docker image for terraform 0.12 (version 2.0.0)
- Updated CHANGELOG.md
- Updated README.md, added latest 0.11 release