### PR TITLE
Add destroyable keys, add keyring resource to outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2019-10-15
 
 ### Added
 
+- Added support for destroyable keys and keyring resource output [#13]
 - Added continuous integration using Cloud Build. [#11]
 
 ## [1.0.0] - 2019-07-19
@@ -26,8 +27,9 @@ and this project adheres to
 - Initial release
 
 [Unreleased]: https://github.com/terraform-google-modules/terraform-google-kms/compare/v1.0.0...HEAD
-[0.1.0]: https://github.com/terraform-google-modules/terraform-google-kms/releases/tag/v0.1.0
+[1.0.0]: https://github.com/terraform-google-modules/terraform-google-kms/releases/tag/v1.1.0
 [1.0.0]: https://github.com/terraform-google-modules/terraform-google-kms/releases/tag/v1.0.0
+[0.1.0]: https://github.com/terraform-google-modules/terraform-google-kms/releases/tag/v0.1.0
 
 [#3]: https://github.com/terraform-google-modules/terraform-google-kms/pull/3
 [#11]: https://github.com/terraform-google-modules/terraform-google-kms/pull/11

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 
 SHELL := /usr/bin/env bash # Make will use bash instead of sh
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.0.1
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.4.3
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Functional examples are included in the
 |------|-------------|:----:|:-----:|:-----:|
 | decrypters | List of comma-separated owners for each key declared in set_decrypters_for. | list(string) | `<list>` | no |
 | encrypters | List of comma-separated owners for each key declared in set_encrypters_for. | list(string) | `<list>` | no |
-| key\_rotation\_period |  | string | `"100000s"` | no |
+| key\_rotation\_period | Key rotation period. | string | `"100000s"` | no |
 | keyring | Keyring name. | string | n/a | yes |
-| keys | Key names. | list(string) | `<list>` | no |
+| keys | Key names for keys that will have 'prevent_destroy' set to true in resource lifecycle. | list(string) | `<list>` | no |
+| keys\_ephemeral | Key names for keys that will have 'prevent_destroy' set to false in resource lifecycle. | list(string) | `<list>` | no |
 | location | Location for the keyring. | string | n/a | yes |
 | owners | List of comma-separated owners for each key declared in set_owners_for. | list(string) | `<list>` | no |
 | project\_id | Project id where the keyring will be created. | string | n/a | yes |
@@ -61,6 +62,7 @@ Functional examples are included in the
 |------|-------------|
 | keyring | Self link of the keyring. |
 | keyring\_name | Name of the keyring. |
+| keyring\_resource | Keyring resource. |
 | keys | Map of key name => key self link. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -16,6 +16,8 @@ This example illustrates how to use the `kms` module.
 | Name | Description |
 |------|-------------|
 | keyring | The name of the keyring. |
+| keys | The generated keys. |
+| location | The location of the keyring. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -19,10 +19,10 @@ provider "google" {
 }
 
 module "kms" {
-  source = "../.."
-
-  project_id = var.project_id
-  keyring    = var.keyring
-  location   = "global"
+  source         = "../.."
+  project_id     = var.project_id
+  keyring        = var.keyring
+  location       = "global"
+  keys_ephemeral = ["one", "two"]
 }
 

--- a/examples/simple_example/outputs.tf
+++ b/examples/simple_example/outputs.tf
@@ -19,3 +19,12 @@ output "keyring" {
   value       = module.kms.keyring_name
 }
 
+output "location" {
+  description = "The location of the keyring."
+  value       = module.kms.keyring_resource.location
+}
+
+output "keys" {
+  description = "The generated keys."
+  value       = module.kms.keys
+}

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,17 @@
  */
 
 locals {
-  keys_by_name = zipmap(var.keys, google_kms_crypto_key.key.*.self_link)
+  keys_ephemeral_set = toset(var.keys_ephemeral)
+  keys_by_name = zipmap(
+    concat(
+      var.keys,
+      [for name in local.keys_ephemeral_set : name]
+    ),
+    concat(
+      google_kms_crypto_key.key[*].self_link,
+      [for key in values(google_kms_crypto_key.key_ephemeral) : key.self_link]
+    )
+  )
 }
 
 resource "google_kms_key_ring" "key_ring" {
@@ -23,6 +33,8 @@ resource "google_kms_key_ring" "key_ring" {
   project  = var.project_id
   location = var.location
 }
+
+# TODO(ludoo): switch non-ephemeral keys and IAM resources to for_each
 
 resource "google_kms_crypto_key" "key" {
   count           = length(var.keys)
@@ -35,30 +47,35 @@ resource "google_kms_crypto_key" "key" {
   }
 }
 
+resource "google_kms_crypto_key" "key_ephemeral" {
+  for_each        = toset(var.keys_ephemeral)
+  name            = each.key
+  key_ring        = google_kms_key_ring.key_ring.self_link
+  rotation_period = var.key_rotation_period
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
 resource "google_kms_crypto_key_iam_binding" "owners" {
-  count = length(var.set_owners_for)
-  role  = "roles/owner"
-
+  count         = length(var.set_owners_for)
+  role          = "roles/owner"
   crypto_key_id = local.keys_by_name[var.set_owners_for[count.index]]
-
-  members = compact(split(",", var.owners[count.index]))
+  members       = compact(split(",", var.owners[count.index]))
 }
 
 resource "google_kms_crypto_key_iam_binding" "decrypters" {
-  count = length(var.set_decrypters_for)
-  role  = "roles/cloudkms.cryptoKeyDecrypter"
-
+  count         = length(var.set_decrypters_for)
+  role          = "roles/cloudkms.cryptoKeyDecrypter"
   crypto_key_id = local.keys_by_name[var.set_decrypters_for[count.index]]
-
-  members = compact(split(",", var.decrypters[count.index]))
+  members       = compact(split(",", var.decrypters[count.index]))
 }
 
 resource "google_kms_crypto_key_iam_binding" "encrypters" {
-  count = length(var.set_encrypters_for)
-  role  = "roles/cloudkms.cryptoKeyEncrypter"
-
+  count         = length(var.set_encrypters_for)
+  role          = "roles/cloudkms.cryptoKeyEncrypter"
   crypto_key_id = local.keys_by_name[element(var.set_encrypters_for, count.index)]
-
-  members = compact(split(",", var.encrypters[count.index]))
+  members       = compact(split(",", var.encrypters[count.index]))
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+# TODO(ludoo): use the 'keyring' output to expose the keyring resource
+
+output "keyring_resource" {
+  description = "Keyring resource."
+  value       = google_kms_key_ring.key_ring
+}
+
 output "keyring" {
   description = "Self link of the keyring."
   value       = google_kms_key_ring.key_ring.self_link

--- a/test/fixtures/simple_example/main.tf
+++ b/test/fixtures/simple_example/main.tf
@@ -25,8 +25,7 @@ resource "random_pet" "main" {
 }
 
 module "example" {
-  source = "../../../examples/simple_example"
-
+  source     = "../../../examples/simple_example"
   project_id = var.project_id
   keyring    = random_pet.main.id
   location   = "global"

--- a/test/fixtures/simple_example/outputs.tf
+++ b/test/fixtures/simple_example/outputs.tf
@@ -21,7 +21,12 @@ output "keyring" {
 
 output "location" {
   description = "Location for the keyring."
-  value       = "global"
+  value       = module.example.location
+}
+
+output "keys" {
+  description = "Generated keys."
+  value       = module.example.keys
 }
 
 output "project_id" {

--- a/test/integration/simple_example/controls/gcloud.rb
+++ b/test/integration/simple_example/controls/gcloud.rb
@@ -26,4 +26,5 @@ control "gcloud" do
     its(:stderr) { should eq "" }
     its(:stdout) { should match "locations/#{attribute("location")}/keyRings/#{attribute("keyring")}" }
   end
+
 end

--- a/test/integration/simple_example/controls/gcp.rb
+++ b/test/integration/simple_example/controls/gcp.rb
@@ -18,4 +18,11 @@ control "gcp" do
   describe google_kms_key_rings(project: attribute('project_id'), location: attribute("location")) do
     its('key_ring_names') { should include attribute("keyring") }
   end
+
+  attribute('keys').each_key do |key|
+    describe google_kms_crypto_key(project: attribute('project_id'), location: attribute("location"),  key_ring_name: attribute("keyring"), name: key) do
+      it {should exist }
+    end
+  end
+
 end

--- a/test/integration/simple_example/inspec.yml
+++ b/test/integration/simple_example/inspec.yml
@@ -13,3 +13,6 @@ attributes:
   - name: location
     required: true
     type: string
+  - name: keys
+    required: true
+    type: hash

--- a/variables.tf
+++ b/variables.tf
@@ -15,65 +15,72 @@
  */
 
 variable "project_id" {
-  type        = string
   description = "Project id where the keyring will be created."
+  type        = string
 }
 
 # cf https://cloud.google.com/kms/docs/locations
 variable "location" {
-  type        = string
   description = "Location for the keyring."
+  type        = string
 }
 
 variable "keyring" {
-  type        = string
   description = "Keyring name."
+  type        = string
 }
 
 variable "keys" {
+  description = "Key names for keys that will have 'prevent_destroy' set to true in resource lifecycle."
   type        = list(string)
-  description = "Key names."
+  default     = []
+}
+
+variable "keys_ephemeral" {
+  description = "Key names for keys that will have 'prevent_destroy' set to false in resource lifecycle."
+  type        = list(string)
   default     = []
 }
 
 variable "set_owners_for" {
-  type        = list(string)
   description = "Name of keys for which owners will be set."
+  type        = list(string)
   default     = []
 }
 
 variable "owners" {
-  type        = list(string)
   description = "List of comma-separated owners for each key declared in set_owners_for."
+  type        = list(string)
   default     = []
 }
 
 variable "set_encrypters_for" {
-  type        = list(string)
   description = "Name of keys for which encrypters will be set."
+  type        = list(string)
   default     = []
 }
 
 variable "encrypters" {
-  type        = list(string)
   description = "List of comma-separated owners for each key declared in set_encrypters_for."
+  type        = list(string)
   default     = []
 }
 
 variable "set_decrypters_for" {
-  type        = list(string)
   description = "Name of keys for which decrypters will be set."
+  type        = list(string)
   default     = []
 }
 
 variable "decrypters" {
-  type        = list(string)
   description = "List of comma-separated owners for each key declared in set_decrypters_for."
+  type        = list(string)
   default     = []
 }
 
 variable "key_rotation_period" {
-  type    = string
-  default = "100000s"
+  description = "Key rotation period."
+  default     = "100000s"
+  type        = string
 }
 


### PR DESCRIPTION
This PR adds two features to the module: ephemeral keys, which are important in  development/testing usage, and full resource output.

Ephemeral keys have lifecycle `prevent_destroy` set to `false`, and use a new set of resources to circumvent Terraform bug [#3116](https://github.com/hashicorp/terraform/issues/3116), and so that backwards compatibility is preserved. The resource set uses `for_each` so that additions/manipulations of the input variable preserve existing resources.

The `keyring_resource` output that exposes the complete keyring resource and preserves backwards compatibility (the `keyring` output is already used for its name).

The test has been expanded to also cover key generation, since ephemeral keys can now be destroyed. Tests need Terraform fix [#22756](https://github.com/hashicorp/terraform/pull/22756) that supports emtpy sets in `for_each`, which was released in `0.12.9`. They don't work with the current developer image, but pass when manually downloading the latest Terraform binary inside the image.