### PR TITLE
Allow setting prevent_destroy lifecycle value on keys (alternate version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.0]
+
 ### Added
 
+- Allow setting prevent_destroy lifecycle value on keys, add keyring resource output [#14]
 - Added continuous integration using Cloud Build. [#11]
 
 ## [1.0.0] - 2019-07-19
@@ -26,8 +29,10 @@ and this project adheres to
 - Initial release
 
 [Unreleased]: https://github.com/terraform-google-modules/terraform-google-kms/compare/v1.0.0...HEAD
-[0.1.0]: https://github.com/terraform-google-modules/terraform-google-kms/releases/tag/v0.1.0
+[1.1.0]: https://github.com/terraform-google-modules/terraform-google-kms/releases/tag/v1.1.0
 [1.0.0]: https://github.com/terraform-google-modules/terraform-google-kms/releases/tag/v1.0.0
+[0.1.0]: https://github.com/terraform-google-modules/terraform-google-kms/releases/tag/v0.1.0
 
-[#3]: https://github.com/terraform-google-modules/terraform-google-kms/pull/3
+[#14]: https://github.com/terraform-google-modules/terraform-google-kms/pull/11
 [#11]: https://github.com/terraform-google-modules/terraform-google-kms/pull/11
+[#3]: https://github.com/terraform-google-modules/terraform-google-kms/pull/3

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 
 SHELL := /usr/bin/env bash # Make will use bash instead of sh
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.0.1
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.4.3
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ Functional examples are included in the
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| decrypters | List of comma-separated owners for each key declared in set_decrypters_for. | list(string) | `<list>` | no |
-| encrypters | List of comma-separated owners for each key declared in set_encrypters_for. | list(string) | `<list>` | no |
+| decrypters | List of comma-separated owners for each key declared in set\_decrypters\_for. | list(string) | `<list>` | no |
+| encrypters | List of comma-separated owners for each key declared in set\_encrypters\_for. | list(string) | `<list>` | no |
 | key\_rotation\_period |  | string | `"100000s"` | no |
 | keyring | Keyring name. | string | n/a | yes |
 | keys | Key names. | list(string) | `<list>` | no |
 | location | Location for the keyring. | string | n/a | yes |
-| owners | List of comma-separated owners for each key declared in set_owners_for. | list(string) | `<list>` | no |
+| owners | List of comma-separated owners for each key declared in set\_owners\_for. | list(string) | `<list>` | no |
+| prevent\_destroy | Set the prevent\_destroy lifecycle attribute on keys. | string | `"true"` | no |
 | project\_id | Project id where the keyring will be created. | string | n/a | yes |
 | set\_decrypters\_for | Name of keys for which decrypters will be set. | list(string) | `<list>` | no |
 | set\_encrypters\_for | Name of keys for which encrypters will be set. | list(string) | `<list>` | no |
@@ -61,6 +62,7 @@ Functional examples are included in the
 |------|-------------|
 | keyring | Self link of the keyring. |
 | keyring\_name | Name of the keyring. |
+| keyring\_resource | Keyring resource. |
 | keys | Map of key name => key self link. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -8,6 +8,7 @@ This example illustrates how to use the `kms` module.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | keyring | Keyring name. | string | n/a | yes |
+| keys | Key names. | list(string) | `<list>` | no |
 | location | Location for the keyring. | string | `"global"` | no |
 | project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
 
@@ -16,6 +17,8 @@ This example illustrates how to use the `kms` module.
 | Name | Description |
 |------|-------------|
 | keyring | The name of the keyring. |
+| keys | List of created kkey names. |
+| location | The location of the keyring. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -19,10 +19,12 @@ provider "google" {
 }
 
 module "kms" {
-  source = "../.."
-
+  source     = "../.."
   project_id = var.project_id
   keyring    = var.keyring
   location   = "global"
+  keys       = var.keys
+  # keys can be destroyed by Terraform
+  prevent_destroy = false
 }
 

--- a/examples/simple_example/outputs.tf
+++ b/examples/simple_example/outputs.tf
@@ -16,6 +16,15 @@
 
 output "keyring" {
   description = "The name of the keyring."
-  value       = module.kms.keyring_name
+  value       = module.kms.keyring_resource.name
 }
 
+output "location" {
+  description = "The location of the keyring."
+  value       = module.kms.keyring_resource.location
+}
+
+output "keys" {
+  description = "List of created kkey names."
+  value       = keys(module.kms.keys)
+}

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -15,18 +15,23 @@
  */
 
 variable "project_id" {
-  type        = string
   description = "The ID of the project in which to provision resources."
+  type        = string
 }
 
 variable "location" {
-  type        = string
   description = "Location for the keyring."
-
-  default = "global"
+  type        = string
+  default     = "global"
 }
 
 variable "keyring" {
-  type        = string
   description = "Keyring name."
+  type        = string
+}
+
+variable "keys" {
+  description = "Key names."
+  type        = list(string)
+  default     = []
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output "keyring" {
   value       = google_kms_key_ring.key_ring.self_link
 }
 
+output "keyring_resource" {
+  description = "Keyring resource."
+  value       = google_kms_key_ring.key_ring
+}
+
 output "keys" {
   description = "Map of key name => key self link."
   value       = local.keys_by_name

--- a/test/fixtures/simple_example/main.tf
+++ b/test/fixtures/simple_example/main.tf
@@ -25,9 +25,9 @@ resource "random_pet" "main" {
 }
 
 module "example" {
-  source = "../../../examples/simple_example"
-
+  source     = "../../../examples/simple_example"
   project_id = var.project_id
   keyring    = random_pet.main.id
   location   = "global"
+  keys       = ["one", "two"]
 }

--- a/test/fixtures/simple_example/outputs.tf
+++ b/test/fixtures/simple_example/outputs.tf
@@ -19,9 +19,14 @@ output "keyring" {
   value       = module.example.keyring
 }
 
+output "keys" {
+  description = "Name of generated keys."
+  value       = module.example.keys
+}
+
 output "location" {
   description = "Location for the keyring."
-  value       = "global"
+  value       = module.example.location
 }
 
 output "project_id" {

--- a/test/integration/simple_example/controls/gcp.rb
+++ b/test/integration/simple_example/controls/gcp.rb
@@ -18,4 +18,11 @@ control "gcp" do
   describe google_kms_key_rings(project: attribute('project_id'), location: attribute("location")) do
     its('key_ring_names') { should include attribute("keyring") }
   end
+
+  attribute('keys').each do |key|
+    describe google_kms_crypto_key(project: attribute('project_id'), location: attribute("location"),  key_ring_name: attribute("keyring"), name: key) do
+      it {should exist }
+    end
+  end
+
 end

--- a/test/integration/simple_example/inspec.yml
+++ b/test/integration/simple_example/inspec.yml
@@ -13,3 +13,6 @@ attributes:
   - name: location
     required: true
     type: string
+  - name: keys
+    required: true
+    type: array

--- a/variables.tf
+++ b/variables.tf
@@ -15,60 +15,65 @@
  */
 
 variable "project_id" {
-  type        = string
   description = "Project id where the keyring will be created."
+  type        = string
 }
 
 # cf https://cloud.google.com/kms/docs/locations
 variable "location" {
-  type        = string
   description = "Location for the keyring."
+  type        = string
 }
 
 variable "keyring" {
-  type        = string
   description = "Keyring name."
+  type        = string
 }
 
 variable "keys" {
-  type        = list(string)
   description = "Key names."
+  type        = list(string)
   default     = []
 }
 
+variable "prevent_destroy" {
+  description = "Set the prevent_destroy lifecycle attribute on keys."
+  default     = true
+}
+
 variable "set_owners_for" {
-  type        = list(string)
   description = "Name of keys for which owners will be set."
+  type        = list(string)
   default     = []
 }
 
 variable "owners" {
-  type        = list(string)
   description = "List of comma-separated owners for each key declared in set_owners_for."
+  type        = list(string)
   default     = []
 }
 
 variable "set_encrypters_for" {
-  type        = list(string)
   description = "Name of keys for which encrypters will be set."
+  type        = list(string)
   default     = []
 }
 
 variable "encrypters" {
-  type        = list(string)
   description = "List of comma-separated owners for each key declared in set_encrypters_for."
+  type        = list(string)
   default     = []
 }
 
 variable "set_decrypters_for" {
-  type        = list(string)
   description = "Name of keys for which decrypters will be set."
+  type        = list(string)
   default     = []
 }
 
 variable "decrypters" {
-  type        = list(string)
   description = "List of comma-separated owners for each key declared in set_decrypters_for."
+  type        = list(string)
   default     = []
 }
 


### PR DESCRIPTION
Aleks, this is more in line with the approach you suggested. It still needs a separate resource for ephemeral keys, as you can't use a variable to set lifecycle attributes (tried, did not work).

I'm fine with either approaches.