### PR TITLE
Feature/module dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Functional examples are included in the
 | set\_decrypters\_for | Name of keys for which decrypters will be set. | list(string) | `<list>` | no |
 | set\_encrypters\_for | Name of keys for which encrypters will be set. | list(string) | `<list>` | no |
 | set\_owners\_for | Name of keys for which owners will be set. | list(string) | `<list>` | no |
+| kms\_depends\_on | Allowing dependency on a particular resource | any | `any` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -19,9 +19,10 @@ locals {
 }
 
 resource "google_kms_key_ring" "key_ring" {
-  name     = var.keyring
-  project  = var.project_id
-  location = var.location
+  depends_on = [var.kms_depends_on]
+  name       = var.keyring
+  project    = var.project_id
+  location   = var.location
 }
 
 resource "google_kms_crypto_key" "key" {

--- a/variables.tf
+++ b/variables.tf
@@ -82,3 +82,7 @@ variable "key_rotation_period" {
   default = "100000s"
 }
 
+variable "kms_depends_on" {
+  type    = any
+  default = null
+}


### PR DESCRIPTION
Allowing module to depend on a particular resource. This could be useful when for example the `cloudkms.googleapis.com` api is not enabled and in one `terraform` run want to achieve enabling `cloudkms.googleapis.com` api  and leveraging it at the same time.

```hcl
resource "google_project_service" "kms" {
  project = var.project_id
  service = "cloudkms.googleapis.com"
  disable_dependent_services = true
}

module "kms" {
  source          = "git::https://github.com/s1mark/terraform-google-kms?ref=feature/module-dependency"
  kms_depends_on  = google_project_service.kms.service
  project_id      = var.project_id
  keyring         = var.keyring
  keys            = var.keys
  location        = var.location
  # keys can be destroyed by Terraform
  prevent_destroy = false
}
```