### PR TITLE
fix: Role binding on multiple keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,22 @@ Functional examples are included in the
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| decrypters | List of comma-separated owners for each key declared in set_decrypters_for. | list(string) | `<list>` | no |
-| encrypters | List of comma-separated owners for each key declared in set_encrypters_for. | list(string) | `<list>` | no |
-| key\_algorithm | The algorithm to use when creating a version based on this template. See the https://cloud.google.com/kms/docs/reference/rest/v1/CryptoKeyVersionAlgorithm for possible inputs. | string | `"GOOGLE_SYMMETRIC_ENCRYPTION"` | no |
-| key\_protection\_level | The protection level to use when creating a version based on this template. Default value: "SOFTWARE" Possible values: ["SOFTWARE", "HSM"] | string | `"SOFTWARE"` | no |
-| key\_rotation\_period |  | string | `"100000s"` | no |
-| keyring | Keyring name. | string | n/a | yes |
-| keys | Key names. | list(string) | `<list>` | no |
-| labels | Labels, provided as a map | map(string) | `<map>` | no |
-| location | Location for the keyring. | string | n/a | yes |
-| owners | List of comma-separated owners for each key declared in set_owners_for. | list(string) | `<list>` | no |
-| prevent\_destroy | Set the prevent_destroy lifecycle attribute on keys. | string | `"true"` | no |
-| project\_id | Project id where the keyring will be created. | string | n/a | yes |
-| set\_decrypters\_for | Name of keys for which decrypters will be set. | list(string) | `<list>` | no |
-| set\_encrypters\_for | Name of keys for which encrypters will be set. | list(string) | `<list>` | no |
-| set\_owners\_for | Name of keys for which owners will be set. | list(string) | `<list>` | no |
+|------|-------------|------|---------|:--------:|
+| decrypters | List of comma-separated owners for each key declared in set\_decrypters\_for. | `list(string)` | `[]` | no |
+| encrypters | List of comma-separated owners for each key declared in set\_encrypters\_for. | `list(string)` | `[]` | no |
+| key\_algorithm | The algorithm to use when creating a version based on this template. See the https://cloud.google.com/kms/docs/reference/rest/v1/CryptoKeyVersionAlgorithm for possible inputs. | `string` | `"GOOGLE_SYMMETRIC_ENCRYPTION"` | no |
+| key\_protection\_level | The protection level to use when creating a version based on this template. Default value: "SOFTWARE" Possible values: ["SOFTWARE", "HSM"] | `string` | `"SOFTWARE"` | no |
+| key\_rotation\_period | n/a | `string` | `"100000s"` | no |
+| keyring | Keyring name. | `string` | n/a | yes |
+| keys | Key names. | `list(string)` | `[]` | no |
+| labels | Labels, provided as a map | `map(string)` | `{}` | no |
+| location | Location for the keyring. | `string` | n/a | yes |
+| owners | List of comma-separated owners for each key declared in set\_owners\_for. | `list(string)` | `[]` | no |
+| prevent\_destroy | Set the prevent\_destroy lifecycle attribute on keys. | `bool` | `true` | no |
+| project\_id | Project id where the keyring will be created. | `string` | n/a | yes |
+| set\_decrypters\_for | Name of keys for which decrypters will be set. | `list(string)` | `[]` | no |
+| set\_encrypters\_for | Name of keys for which encrypters will be set. | `list(string)` | `[]` | no |
+| set\_owners\_for | Name of keys for which owners will be set. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -6,11 +6,11 @@ This example illustrates how to use the `kms` module.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| keyring | Keyring name. | string | n/a | yes |
-| keys | Key names. | list(string) | `<list>` | no |
-| location | Location for the keyring. | string | `"global"` | no |
-| project\_id | The ID of the project in which to provision resources. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| keyring | Keyring name. | `string` | n/a | yes |
+| keys | Key names. | `list(string)` | `[]` | no |
+| location | Location for the keyring. | `string` | `"global"` | no |
+| project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -64,20 +64,20 @@ resource "google_kms_crypto_key_iam_binding" "owners" {
   count         = length(var.set_owners_for)
   role          = "roles/owner"
   crypto_key_id = local.keys_by_name[var.set_owners_for[count.index]]
-  members       = compact(split(",", var.owners[count.index]))
+  members       = var.owners
 }
 
 resource "google_kms_crypto_key_iam_binding" "decrypters" {
   count         = length(var.set_decrypters_for)
   role          = "roles/cloudkms.cryptoKeyDecrypter"
   crypto_key_id = local.keys_by_name[var.set_decrypters_for[count.index]]
-  members       = compact(split(",", var.decrypters[count.index]))
+  members       = var.decrypters
 }
 
 resource "google_kms_crypto_key_iam_binding" "encrypters" {
   count         = length(var.set_encrypters_for)
   role          = "roles/cloudkms.cryptoKeyEncrypter"
   crypto_key_id = local.keys_by_name[element(var.set_encrypters_for, count.index)]
-  members       = compact(split(",", var.encrypters[count.index]))
+  members       = var.encrypters
 }
 


### PR DESCRIPTION
Fix mutliple users and multiple keys role bindings on `encrypters`, `decrypters` variables.

For example
on the resource google_kms_crypto_key_iam_binding owners
the members set depends on the numbers of keys.

Now all `decrypters` and `encrypters` defined as applied and no matter the number of keys defined.