### PR TITLE
Removing string split and element index on IAM membership lists

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,20 +64,20 @@ resource "google_kms_crypto_key_iam_binding" "owners" {
   count         = length(var.set_owners_for)
   role          = "roles/owner"
   crypto_key_id = local.keys_by_name[var.set_owners_for[count.index]]
-  members       = compact(split(",", var.owners[count.index]))
+  members       = compact(var.owners)
 }
 
 resource "google_kms_crypto_key_iam_binding" "decrypters" {
   count         = length(var.set_decrypters_for)
   role          = "roles/cloudkms.cryptoKeyDecrypter"
   crypto_key_id = local.keys_by_name[var.set_decrypters_for[count.index]]
-  members       = compact(split(",", var.decrypters[count.index]))
+  members       = compact(var.decrypters)
 }
 
 resource "google_kms_crypto_key_iam_binding" "encrypters" {
   count         = length(var.set_encrypters_for)
   role          = "roles/cloudkms.cryptoKeyEncrypter"
   crypto_key_id = local.keys_by_name[element(var.set_encrypters_for, count.index)]
-  members       = compact(split(",", var.encrypters[count.index]))
+  members       = compact(var.encrypters)
 }
 


### PR DESCRIPTION
The split function is a string processing function, not a list function. The code in these resources was splitting the list element referenced and assigning the resulting list (of one element) to the key. Index isn't needed here, as the intent is to assign the whole membership list to each key in var.set_[decrypters|encrypters|owners]_for.

This change restores the expected behavior of the module, where the whole list (var.[decrypers|encrypters|owners]) is applied to each key.