### PR TITLE
Create dependency with grant

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,8 +17,9 @@
 output "keyring" {
   description = "Self link of the keyring."
   value       = google_kms_key_ring.key_ring.self_link
+
+  # The grants are important to the key be ready to use.
   depends_on = [
-    # The grants are important to the key be ready to use.
     google_kms_crypto_key_iam_binding.owners,
     google_kms_crypto_key_iam_binding.decrypters,
     google_kms_crypto_key_iam_binding.encrypters,
@@ -28,8 +29,9 @@ output "keyring" {
 output "keyring_resource" {
   description = "Keyring resource."
   value       = google_kms_key_ring.key_ring
+
+  # The grants are important to the key be ready to use.
   depends_on = [
-    # The grants are important to the key be ready to use.
     google_kms_crypto_key_iam_binding.owners,
     google_kms_crypto_key_iam_binding.decrypters,
     google_kms_crypto_key_iam_binding.encrypters,
@@ -39,8 +41,9 @@ output "keyring_resource" {
 output "keys" {
   description = "Map of key name => key self link."
   value       = local.keys_by_name
+
+  # The grants are important to the key be ready to use.
   depends_on = [
-    # The grants are important to the key be ready to use.
     google_kms_crypto_key_iam_binding.owners,
     google_kms_crypto_key_iam_binding.decrypters,
     google_kms_crypto_key_iam_binding.encrypters,
@@ -50,8 +53,9 @@ output "keys" {
 output "keyring_name" {
   description = "Name of the keyring."
   value       = google_kms_key_ring.key_ring.name
+
+  # The grants are important to the key be ready to use.
   depends_on = [
-    # The grants are important to the key be ready to use.
     google_kms_crypto_key_iam_binding.owners,
     google_kms_crypto_key_iam_binding.decrypters,
     google_kms_crypto_key_iam_binding.encrypters,

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,20 +17,44 @@
 output "keyring" {
   description = "Self link of the keyring."
   value       = google_kms_key_ring.key_ring.self_link
+  depends_on = [
+    # The grants are important to the key be ready to use.
+    google_kms_crypto_key_iam_binding.owners,
+    google_kms_crypto_key_iam_binding.decrypters,
+    google_kms_crypto_key_iam_binding.encrypters,
+  ]
 }
 
 output "keyring_resource" {
   description = "Keyring resource."
   value       = google_kms_key_ring.key_ring
+  depends_on = [
+    # The grants are important to the key be ready to use.
+    google_kms_crypto_key_iam_binding.owners,
+    google_kms_crypto_key_iam_binding.decrypters,
+    google_kms_crypto_key_iam_binding.encrypters,
+  ]
 }
 
 output "keys" {
   description = "Map of key name => key self link."
   value       = local.keys_by_name
+  depends_on = [
+    # The grants are important to the key be ready to use.
+    google_kms_crypto_key_iam_binding.owners,
+    google_kms_crypto_key_iam_binding.decrypters,
+    google_kms_crypto_key_iam_binding.encrypters,
+  ]
 }
 
 output "keyring_name" {
   description = "Name of the keyring."
   value       = google_kms_key_ring.key_ring.name
+  depends_on = [
+    # The grants are important to the key be ready to use.
+    google_kms_crypto_key_iam_binding.owners,
+    google_kms_crypto_key_iam_binding.decrypters,
+    google_kms_crypto_key_iam_binding.encrypters,
+  ]
 }
 


### PR DESCRIPTION
Fixes issue: #39

### Problem
When you use KMS module adding owners/encrypters/decrypters param the module returns the created key before the grant access be applied, this cause problems when you need to used the key in other module forcing you to add `depends_on = [module.kms]`

### Solution
Added the dependence between the outputs and the grant access:

https://github.com/terraform-google-modules/terraform-google-kms/pull/46/files#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R22

```hcl
# The grants are important to the key be ready to use.
depends_on = [
  google_kms_crypto_key_iam_binding.owners,
  google_kms_crypto_key_iam_binding.decrypters,
  google_kms_crypto_key_iam_binding.encrypters,
]
```
It is a good practice [include a comment explaining why the depends_on is being used](https://www.terraform.io/docs/language/values/outputs.html#depends_on-explicit-output-dependencies).

