### PR TITLE
Fix the integration test

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,8 +17,9 @@
 output "keyring" {
   description = "Self link of the keyring."
   value       = google_kms_key_ring.key_ring.self_link
+
+  # The grants are important to the key be ready to use.
   depends_on = [
-    # The grants are important to the key be ready to use.
     google_kms_crypto_key_iam_binding.owners,
     google_kms_crypto_key_iam_binding.decrypters,
     google_kms_crypto_key_iam_binding.encrypters,
@@ -28,8 +29,9 @@ output "keyring" {
 output "keyring_resource" {
   description = "Keyring resource."
   value       = google_kms_key_ring.key_ring
+
+  # The grants are important to the key be ready to use.
   depends_on = [
-    # The grants are important to the key be ready to use.
     google_kms_crypto_key_iam_binding.owners,
     google_kms_crypto_key_iam_binding.decrypters,
     google_kms_crypto_key_iam_binding.encrypters,
@@ -39,8 +41,9 @@ output "keyring_resource" {
 output "keys" {
   description = "Map of key name => key self link."
   value       = local.keys_by_name
+
+  # The grants are important to the key be ready to use.
   depends_on = [
-    # The grants are important to the key be ready to use.
     google_kms_crypto_key_iam_binding.owners,
     google_kms_crypto_key_iam_binding.decrypters,
     google_kms_crypto_key_iam_binding.encrypters,
@@ -50,8 +53,9 @@ output "keys" {
 output "keyring_name" {
   description = "Name of the keyring."
   value       = google_kms_key_ring.key_ring.name
+
+  # The grants are important to the key be ready to use.
   depends_on = [
-    # The grants are important to the key be ready to use.
     google_kms_crypto_key_iam_binding.owners,
     google_kms_crypto_key_iam_binding.decrypters,
     google_kms_crypto_key_iam_binding.encrypters,

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,20 +17,44 @@
 output "keyring" {
   description = "Self link of the keyring."
   value       = google_kms_key_ring.key_ring.self_link
+  depends_on = [
+    # The grants are important to the key be ready to use.
+    google_kms_crypto_key_iam_binding.owners,
+    google_kms_crypto_key_iam_binding.decrypters,
+    google_kms_crypto_key_iam_binding.encrypters,
+  ]
 }
 
 output "keyring_resource" {
   description = "Keyring resource."
   value       = google_kms_key_ring.key_ring
+  depends_on = [
+    # The grants are important to the key be ready to use.
+    google_kms_crypto_key_iam_binding.owners,
+    google_kms_crypto_key_iam_binding.decrypters,
+    google_kms_crypto_key_iam_binding.encrypters,
+  ]
 }
 
 output "keys" {
   description = "Map of key name => key self link."
   value       = local.keys_by_name
+  depends_on = [
+    # The grants are important to the key be ready to use.
+    google_kms_crypto_key_iam_binding.owners,
+    google_kms_crypto_key_iam_binding.decrypters,
+    google_kms_crypto_key_iam_binding.encrypters,
+  ]
 }
 
 output "keyring_name" {
   description = "Name of the keyring."
   value       = google_kms_key_ring.key_ring.name
+  depends_on = [
+    # The grants are important to the key be ready to use.
+    google_kms_crypto_key_iam_binding.owners,
+    google_kms_crypto_key_iam_binding.decrypters,
+    google_kms_crypto_key_iam_binding.encrypters,
+  ]
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,48 +17,20 @@
 output "keyring" {
   description = "Self link of the keyring."
   value       = google_kms_key_ring.key_ring.self_link
-
-  # The grants are important to the key be ready to use.
-  depends_on = [
-    google_kms_crypto_key_iam_binding.owners,
-    google_kms_crypto_key_iam_binding.decrypters,
-    google_kms_crypto_key_iam_binding.encrypters,
-  ]
 }
 
 output "keyring_resource" {
   description = "Keyring resource."
   value       = google_kms_key_ring.key_ring
-
-  # The grants are important to the key be ready to use.
-  depends_on = [
-    google_kms_crypto_key_iam_binding.owners,
-    google_kms_crypto_key_iam_binding.decrypters,
-    google_kms_crypto_key_iam_binding.encrypters,
-  ]
 }
 
 output "keys" {
   description = "Map of key name => key self link."
   value       = local.keys_by_name
-
-  # The grants are important to the key be ready to use.
-  depends_on = [
-    google_kms_crypto_key_iam_binding.owners,
-    google_kms_crypto_key_iam_binding.decrypters,
-    google_kms_crypto_key_iam_binding.encrypters,
-  ]
 }
 
 output "keyring_name" {
   description = "Name of the keyring."
   value       = google_kms_key_ring.key_ring.name
-
-  # The grants are important to the key be ready to use.
-  depends_on = [
-    google_kms_crypto_key_iam_binding.owners,
-    google_kms_crypto_key_iam_binding.decrypters,
-    google_kms_crypto_key_iam_binding.encrypters,
-  ]
 }
 

--- a/test/integration/simple_example/inspec.yml
+++ b/test/integration/simple_example/inspec.yml
@@ -2,7 +2,7 @@ name: simple_example
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    tag: v0.10.0
+    tag: v1.8.8
 attributes:
   - name: project_id
     required: true


### PR DESCRIPTION
The integration test is broken, changing the version of inspec-gcp to v1.8.8 will fixes

```hcl
name: simple_example
depends:
  - name: inspec-gcp
    git: https://github.com/inspec/inspec-gcp.git
    tag: v1.8.8
```