### PR TITLE
Fix issue importing keyring when key state does not match config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,8 @@
  */
 
 locals {
-  keys_by_name = zipmap(var.keys, var.prevent_destroy ? slice(google_kms_crypto_key.key[*].id, 0, length(var.keys)) : slice(google_kms_crypto_key.key_ephemeral[*].id, 0, length(var.keys)))
+  _number_key_resources = length(google_kms_crypto_key.key) + length(google_kms_crypto_key.key_ephemeral)
+  keys_by_name          = local._number_key_resources == 0 ? {} : zipmap(var.keys, var.prevent_destroy ? slice(google_kms_crypto_key.key[*].self_link, 0, local._number_key_resources) : slice(google_kms_crypto_key.key_ephemeral[*].self_link, 0, local._number_key_resources))
 }
 
 resource "google_kms_key_ring" "key_ring" {


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-kms/issues/44

The basis for this fix should be explained as it was missing by the original author of the module.

If we view the effect of existing state, having been applied, or planned state giving access to resources then the original module works.

Where it fails is on import which only targets the single resource and during import other resources are not created, this means that the group of google_kms_crypto_key.key and key_ephemerals do not exist at the point of import then since this is not a plan the predicted resources are also not present during the import.

The new approach is to count the number of actual key resources available (created elsewhere in the module) which means that during an import only resources that are actually present from previous runs will be counted but if none are present then the result is zero.

We then use this value to conditionally either use an empty map if 0 resources are counted or, if there are resources present, to adopt the previous approach of generating the map indicating the planned state.

I've used an intermediate variable here to bring down repetition a little.. let me know if you really want me to remove it but I think as an approach an intermediate variable can help make these things a lot more readable and avoid repeat evaluations. My convention for these things is to prefix with an underscore. The approach of setting locals from state generated from resources is fairly sound as long as you do not create a 'cycle' as Terraform calls it. The actual number of resources is generated independently in the plan phase from the input array of keys vs this variable that gathers that information and/or state already present in key that may already be there.