### PR TITLE
fix: Change default rotation period from 28 hours to 90 days 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Functional examples are included in the
 | encrypters | List of comma-separated owners for each key declared in set\_encrypters\_for. | `list(string)` | `[]` | no |
 | key\_algorithm | The algorithm to use when creating a version based on this template. See the https://cloud.google.com/kms/docs/reference/rest/v1/CryptoKeyVersionAlgorithm for possible inputs. | `string` | `"GOOGLE_SYMMETRIC_ENCRYPTION"` | no |
 | key\_protection\_level | The protection level to use when creating a version based on this template. Default value: "SOFTWARE" Possible values: ["SOFTWARE", "HSM"] | `string` | `"SOFTWARE"` | no |
-| key\_rotation\_period | Generate a new key every time this period passes. | `string` | `"100000s"` | no |
+| key\_rotation\_period | Generate a new key every time this period passes. | `string` | `"7776000s"` | no |
 | keyring | Keyring name. | `string` | n/a | yes |
 | keys | Key names. | `list(string)` | `[]` | no |
 | labels | Labels, provided as a map | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -87,7 +87,7 @@ variable "decrypters" {
 variable "key_rotation_period" {
   description = "Generate a new key every time this period passes."
   type        = string
-  default     = "100000s"
+  default     = "7776000s"
 }
 
 variable "key_algorithm" {


### PR DESCRIPTION
Based on Google public docs (https://cloud.google.com/kms/docs/key-rotation#how_often_to_rotate_keys), changing the default key rotation period from ~28 hours to a suggested 90  days.  