### PR TITLE
chore: Fix a keyring flaky test

### DIFF
--- a/test/integration/simple_example/simple_example_test.go
+++ b/test/integration/simple_example/simple_example_test.go
@@ -16,7 +16,6 @@ package simple_example
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
@@ -34,16 +33,8 @@ func TestSimpleExample(t *testing.T) {
 		location := bpt.GetStringOutput("location")
 		keys := [2]string{"one", "two"}
 
-		resultArray := gcloud.Runf(t, "--project=%s kms keyrings list --location %s", projectId, location).Array()
-		found := false
-		for _, item := range resultArray {
-			name := item.Get("name").String()
-			if strings.Contains(name, fmt.Sprintf("projects/%s/locations/%s/keyRings/%s", projectId, location, keyring)) {
-				found = true
-				break
-			}
-		}
-		assert.True(found, "Contains KeyRing")
+		op := gcloud.Runf(t, "--project=%s kms keyrings list --location %s --sort-by ~createTime", projectId, location).Array()[0].Get("name")
+		assert.Contains(op.String(), fmt.Sprintf("projects/%s/locations/%s/keyRings/%s", projectId, location, keyring), "Contains KeyRing")
 
 		op1 := gcloud.Runf(t, "kms keys list --project=%s --keyring %s --location %s", projectId, keyring, location).Array()
 		for index, element := range op1 {

--- a/test/integration/simple_example/simple_example_test.go
+++ b/test/integration/simple_example/simple_example_test.go
@@ -16,6 +16,7 @@ package simple_example
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
@@ -33,8 +34,16 @@ func TestSimpleExample(t *testing.T) {
 		location := bpt.GetStringOutput("location")
 		keys := [2]string{"one", "two"}
 
-		op := gcloud.Runf(t, "--project=%s kms keyrings list --location %s", projectId, location).Array()[0].Get("name")
-		assert.Contains(op.String(), fmt.Sprintf("projects/%s/locations/%s/keyRings/%s", projectId, location, keyring), "Contains KeyRing")
+		resultArray := gcloud.Runf(t, "--project=%s kms keyrings list --location %s", projectId, location).Array()
+		found := false
+		for _, item := range resultArray {
+			name := item.Get("name").String()
+			if strings.Contains(name, fmt.Sprintf("projects/%s/locations/%s/keyRings/%s", projectId, location, keyring)) {
+				found = true
+				break
+			}
+		}
+		assert.True(found, "Contains KeyRing")
 
 		op1 := gcloud.Runf(t, "kms keys list --project=%s --keyring %s --location %s", projectId, keyring, location).Array()
 		for index, element := range op1 {


### PR DESCRIPTION
The goal of this PR is to fix this [opened issue](https://github.com/terraform-google-modules/terraform-google-kms/issues/132) related to a flaky test on [TestSimpleExample](https://github.com/terraform-google-modules/terraform-google-kms/blob/32d859d35e00d2d3f8eb2a06febe45c7a9fdd43c/test/integration/simple_example/simple_example_test.go#L26)

This flaky error is being caused due to the default sort in a gcloud command (`kms keyrings list`). Test expect to always use the first keyring returned, but in order to do that we need to sort by `~createTime `instead.