### PR TITLE
feat: Add support for EXTERNAL_VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ Functional examples are included in the
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| crypto\_key\_backend | (Optional) The resource name of the backend environment associated with all CryptoKeyVersions within this CryptoKey. The resource name is in the format 'projects//locations//ekmConnections/*' and only applies to 'EXTERNAL\_VPC' keys. | `string` | `""` | no |
 | decrypters | List of comma-separated owners for each key declared in set\_decrypters\_for. | `list(string)` | `[]` | no |
 | encrypters | List of comma-separated owners for each key declared in set\_encrypters\_for. | `list(string)` | `[]` | no |
 | key\_algorithm | The algorithm to use when creating a version based on this template. See the https://cloud.google.com/kms/docs/reference/rest/v1/CryptoKeyVersionAlgorithm for possible inputs. | `string` | `"GOOGLE_SYMMETRIC_ENCRYPTION"` | no |
 | key\_destroy\_scheduled\_duration | Set the period of time that versions of keys spend in the DESTROY\_SCHEDULED state before transitioning to DESTROYED. | `string` | `null` | no |
-| key\_protection\_level | The protection level to use when creating a version based on this template. Default value: "SOFTWARE" Possible values: ["SOFTWARE", "HSM"] | `string` | `"SOFTWARE"` | no |
+| key\_protection\_level | The protection level to use when creating a version based on this template. Default value: "SOFTWARE" Possible values: ["SOFTWARE", "HSM", "EXTERNAL", "EXTERNAL\_VPC"] | `string` | `"SOFTWARE"` | no |
 | key\_rotation\_period | Generate a new key every time this period passes. | `string` | `"7776000s"` | no |
 | keyring | Keyring name. | `string` | n/a | yes |
 | keys | Key names. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ resource "google_kms_crypto_key" "key" {
   key_ring        = google_kms_key_ring.key_ring.id
   rotation_period = var.key_rotation_period
   purpose         = var.purpose
+  crypto_key_backend = var.crypto_key_backend
 
   lifecycle {
     prevent_destroy = true
@@ -51,6 +52,7 @@ resource "google_kms_crypto_key" "key_ephemeral" {
   key_ring        = google_kms_key_ring.key_ring.id
   rotation_period = var.key_rotation_period
   purpose         = var.purpose
+  crypto_key_backend = var.crypto_key_backend
 
   lifecycle {
     prevent_destroy = false

--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "key_algorithm" {
 
 variable "key_protection_level" {
   type        = string
-  description = "The protection level to use when creating a version based on this template. Default value: \"SOFTWARE\" Possible values: [\"SOFTWARE\", \"HSM\"]"
+  description = "The protection level to use when creating a version based on this template. Default value: \"SOFTWARE\" Possible values: [\"SOFTWARE\", \"HSM\", \"EXTERNAL\", \"EXTERNAL_VPC\"]"
   default     = "SOFTWARE"
 }
 
@@ -112,4 +112,10 @@ variable "labels" {
   type        = map(string)
   description = "Labels, provided as a map"
   default     = {}
+}
+
+variable "crypto_key_backend" {
+  type        = string
+  description = "(Optional) The resource name of the backend environment associated with all CryptoKeyVersions within this CryptoKey. The resource name is in the format 'projects//locations//ekmConnections/*' and only applies to 'EXTERNAL_VPC' keys."
+  default     = ""
 }


### PR DESCRIPTION
The goal of this PR is to introduce support for [crypto_key_backend](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key#crypto_key_backend) on KMS module.