### PR TITLE
fix(TPG>=5.23)!: bump TPG for crypto_key_backend

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.87, < 6"
+      version = ">= 5.23.0, < 6"
     }
   }
 


### PR DESCRIPTION
Fixes: https://github.com/terraform-google-modules/terraform-google-kms/pull/137#discussion_r1556474667