### PR TITLE
fix: Updating output type

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -127,7 +127,9 @@ spec:
     outputs:
       - name: key_id_list
         description: The list of the crypto key IDs.
-        type: list(string)
+        type:
+          - list
+          - string
       - name: keyring
         description: Self link of the keyring.
         type: string


### PR DESCRIPTION
fix: Updating output type fro following error 

```
failed to create output variable "key_id_list": invalid primitive type name "list(string)"
```